### PR TITLE
Style of the sidebar for icon download

### DIFF
--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -148,7 +148,7 @@ body {
 #icon-details [type="checkbox"]:not(:checked) + label, 
 #icon-details [type="checkbox"]:checked + label {
   cursor: pointer;
-  padding: 0 32px;
+  padding-left: 32px;
   position: relative;
 }
 
@@ -167,6 +167,9 @@ body {
   width: 16px;
   height: 16px;
   offset-inline-start: 0;
+}
+
+#icon-details [type="checkbox"]:checked + label::after {
   background: url("../images/check.svg") no-repeat center center;
 }
 

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -288,7 +288,7 @@ input:focus + .toggle {
 }
 
 input:checked + .toggle:before {
-  transform: translateX(20px);
+  transform: translateX(18px);
   border-color: var(--blue-50);
 }
 

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -49,6 +49,8 @@ body {
 /** icon details **/
 
 #icon-details {
+  display: flex;
+  flex-direction: column;
   background-color: var(--white);
   height: calc(100vh - 50px);
   position: fixed;
@@ -69,9 +71,6 @@ body {
 }
 
 #icon-details footer {
-  position: absolute;
-  z-index: 1;
-  bottom: 0;
   display: flex;
   justify-content: flex-end;
   padding: 24px 0;

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -1,5 +1,9 @@
 @import url(https://fonts.googleapis.com/css?family=Fira+Sans:400,300);
 
+* {
+  box-sizing: border-box;
+}
+
 /** Global styles **/
 body {
   font-family: "Fira Sans", Arial, sans-serif;
@@ -7,7 +11,6 @@ body {
   padding: 0;
   color: #333;
   background: #f9f9fa;
-  box-sizing: border-box;
 }
 .hidden {
   display: none !important;
@@ -19,7 +22,7 @@ body {
 }
 #headline {
   font-size: 40px;
-  font-weight: 300;
+  font-weight: 400;
   padding: 50px 100px;
   background: white;
 }
@@ -30,13 +33,35 @@ body {
 /** icon details **/
 #icon-details {
   background: white;
-  height: calc(100vh - 70px);
+  height: 100vh;
   position: fixed;
-  right: -320px;
-  top: 50px;
+  right: -440px;
+  top: 0;
   transition: right 1s cubic-bezier(.07,.95,0,1);;
-  width: 300px;
-  padding: 10px;
+  width: 400px;
+  border-left: solid 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08);
+}
+
+#icon-details header {
+  padding: 48px 48px 0 48px;
+}
+
+#icon-details main {
+  padding: 0 48px;
+}
+
+#icon-details footer {
+  position: fixed;
+  z-index: 1;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  padding: 24px 0;
+  width: 400px;
+  padding: 24px 48px;
+  border-top: solid 1px rgba(0, 0, 0, 0.1);
+  background-color: rgba(215, 215, 219, .2);
 }
 
 #icon-details.show {
@@ -44,20 +69,20 @@ body {
 }
 
 #icon-details h1 {
-  font-size: 20px;
-  font-weight: unset;
+  font-size: 32px;
+  font-weight: 400;
+  margin: 0 0 24px 0;
 }
 
 #icon-details .close-button {
-  background-image: url('../../icons/deprecated-developer/close.svg');
+  background-image: url('../../icons/new/stop-16.svg');
   background-position: center;
   background-size: contain;
-  display: inline-block;
-  height: 24px;
   position: absolute;
-  right: 12px;
   top: 24px;
+  right: 24px;
   width: 24px;
+  height: 24px;
 }
 
 #icon-details .close-button:hover {
@@ -69,38 +94,157 @@ body {
 }
 
 #icon-details .section {
-  margin: 16px 0;
+  margin: 48px 0;
 }
+
 #icon-details .title {
   font-weight: bold;
 }
+
 #icon-details .preview {
-  border-bottom: 1px solid #333;
-  border-top: 1px solid #333;
-  padding: 32px;
+  border-top: solid 1px rgba(0, 0, 0, 0.1);
+  padding: 32px 32px 16px 32px;
   text-align: center;
 }
+
 #icon-details img {
-  width: 32px;
+  width: 64px;
 }
+
 #icon-details .name {
-  margin-bottom: 20px;
+  padding: 0 32px 32px 32px;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.1);
+  text-align: center;
   text-transform: capitalize;
 }
-#download {
-  margin-top: 32px;
-  text-align: center;
+
+/** icon details checkbox **/
+
+.checkbox, 
+.radio {
+  margin: 12px 0;
 }
-#download a {
-  background-color: #0a84ff;
-  border: none;
-  color: #fff;
-  padding: 10px 14px;
-  text-decoration: none;
+
+#icon-details [type="checkbox"]:not(:checked) + label, 
+#icon-details [type="checkbox"]:checked + label {
+  cursor: pointer;
+  padding: 0 32px;
+  position: relative;
 }
-#download a img {
-  vertical-align: sub;
+
+#icon-details [type="checkbox"]:not(:checked), 
+#icon-details [type="checkbox"]:checked {
+  offset-inline-start: -9999px;
+  position: absolute;
+}
+
+#icon-details [type="checkbox"]:not(:checked) + label::after, 
+#icon-details [type="checkbox"]:checked + label::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  padding: 3px;
   width: 16px;
+  height: 16px;
+  offset-inline-start: 0;
+  background: url("../images/check.svg") no-repeat center center;
+}
+
+#icon-details [type="checkbox"]:not(:checked) + label::before, 
+#icon-details [type="checkbox"]:checked + label::before {
+  background: white;
+  border: 1px solid #c1c1c1;
+  border-radius: 3px;
+  content: '';
+  height: 20px;
+  offset-inline-start: 0;
+  position: absolute;
+  top: 0;
+  width: 20px;
+}
+
+#icon-details [type="checkbox"]:disabled + label{
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/** icons details radio **/
+
+#icon-details [type="radio"]:not(:checked) + label, 
+#icon-details [type="radio"]:checked + label {
+  cursor: pointer;
+  padding: 0 32px;
+  position: relative;
+}
+
+#icon-details [type="radio"]:not(:checked), 
+#icon-details [type="radio"]:checked {
+  offset-inline-start: -9999px;
+  position: absolute;
+}
+
+#icon-details [type="radio"]:not(:checked) + label::after, 
+#icon-details [type="radio"]:checked + label::after {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  content: '';
+  width: 12px;
+  height: 12px;
+  background-color: #0a84ff;
+  border-radius: 100%;
+}
+
+#icon-details [type="radio"]:not(:checked) + label::before, 
+#icon-details [type="radio"]:checked + label::before {
+  background: white;
+  border: 1px solid #c1c1c1;
+  border-radius: 100%;
+  content: '';
+  width: 20px;
+  height: 20px;
+  offset-inline-start: 0;
+  position: absolute;
+  top: 0;
+}
+
+label span {
+  display: inline;
+  vertical-align: bottom;
+  line-height: 1;
+}
+
+label small {
+  vertical-align: bottom;
+  font-size: 12px;
+  line-height: 1.05;
+  margin-left: 12px;
+  font-weight: 400;
+  text-transform: uppercase;
+}
+
+#download {
+  text-align: right;
+  cursor: pointer;
+}
+
+#cancel a {
+  display: block;
+  color: #3b3b3b;
+  margin: 12px 24px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+#download a {
+  display: block;
+  background-color: #0a84ff;
+  color: white;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  padding: 12px 24px;
+  text-decoration: none;
+  border-radius: 3px;
 }
 
 /** Embed version **/
@@ -130,7 +274,6 @@ body {
   border-style: solid;
   position: sticky;
   top: 50px;
-  box-sizing: border-box;
   background-image: url(../../icons/new/search-16.svg);
   background-position: calc((100px - 16px) / 2) center;
   background-repeat: no-repeat;
@@ -142,7 +285,7 @@ body {
 }
 #search-input[disabled] {
   opacity: 0.5;
-  background-color: #fff;
+  background-color: white;
 }
 
 /** Directory display **/

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -1,5 +1,16 @@
 @import url(https://fonts.googleapis.com/css?family=Fira+Sans:400,300);
 
+:root {
+  --blue-50: #0a84ff;
+  --blue-60: #0060df;
+  --grey-10: #f9f9fa;
+  --grey-30: #d7d7db;
+  --grey-50: #737373;
+  --grey-70: #4a4a4f;
+  --grey-90: #0c0c0d;
+  --photon-timing-fuction: cubic-bezier(.07,.95,0,1);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -9,35 +20,40 @@ body {
   font-family: "Fira Sans", Arial, sans-serif;
   margin: 0;
   padding: 0;
-  color: #333;
-  background: #f9f9fa;
+  color: var(--grey-90);
+  background-color: var(--grey-10);
 }
+
 .hidden {
   display: none !important;
 }
+
 #loading {
   text-align: center;
   font-size: 20px;
   margin-top: 30px;
 }
+
 #headline {
   font-size: 40px;
   font-weight: 400;
   padding: 50px 100px;
   background: white;
 }
+
 #icon-list {
   margin: 0 300px 0 100px;
 }
 
 /** icon details **/
+
 #icon-details {
   background: white;
   height: 100vh;
   position: fixed;
   right: -440px;
   top: 0;
-  transition: right 1s cubic-bezier(.07,.95,0,1);;
+  transition: right 1s var(--photon-timing-fuction);
   width: 400px;
   border-left: solid 1px rgba(0, 0, 0, 0.1);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08);
@@ -86,11 +102,11 @@ body {
 }
 
 #icon-details .close-button:hover {
-  background-color: #ebebeb;
+  background-color: var(--grey-30);
 }
 
 #icon-details .close-button:active {
-  background-color: #dcdcdc;
+  background-color: var(--grey-50);
 }
 
 #icon-details .section {
@@ -98,7 +114,8 @@ body {
 }
 
 #icon-details .title {
-  font-weight: bold;
+  display: inline-block;
+  font-weight: 500;
 }
 
 #icon-details .preview {
@@ -153,7 +170,7 @@ body {
 #icon-details [type="checkbox"]:not(:checked) + label::before, 
 #icon-details [type="checkbox"]:checked + label::before {
   background: white;
-  border: 1px solid #c1c1c1;
+  border: 1px solid var(--grey-30);
   border-radius: 3px;
   content: '';
   height: 20px;
@@ -191,14 +208,14 @@ body {
   content: '';
   width: 12px;
   height: 12px;
-  background-color: #0a84ff;
+  background-color: var(--blue-50);
   border-radius: 100%;
 }
 
 #icon-details [type="radio"]:not(:checked) + label::before, 
 #icon-details [type="radio"]:checked + label::before {
   background: white;
-  border: 1px solid #c1c1c1;
+  border: 1px solid var(--grey-30);
   border-radius: 100%;
   content: '';
   width: 20px;
@@ -223,6 +240,59 @@ label small {
   text-transform: uppercase;
 }
 
+/** Toggle **/
+
+ /* The switch - the box around the slider */
+
+.switch {
+  position: relative;
+  display: inline-block;
+  float: right;
+  width: 40px;
+  height: 20px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {display:none;}
+
+/* The slider */
+.toggle {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--grey-30);
+  transition: all .3s var(--photon-timing-fuction);
+  border-radius: 20px;
+}
+
+.toggle:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 0;
+  bottom: 0;
+  background-color: white;
+  transition: all .3s var(--photon-timing-fuction);
+  border-radius: 100%;
+  border: 1px solid var(--grey-30);
+}
+
+input:checked + .toggle,
+input:focus + .toggle {
+  background-color: var(--blue-50);
+}
+
+input:checked + .toggle:before {
+  transform: translateX(20px);
+  border-color: var(--blue-50);
+}
+
+/** Footer Buttons **/
+
 #download {
   text-align: right;
   cursor: pointer;
@@ -230,7 +300,7 @@ label small {
 
 #cancel a {
   display: block;
-  color: #3b3b3b;
+  color: var(--grey-90);
   margin: 12px 24px;
   text-decoration: none;
   cursor: pointer;
@@ -238,7 +308,7 @@ label small {
 
 #download a {
   display: block;
-  background-color: #0a84ff;
+  background-color: var(--blue-50);
   color: white;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
@@ -248,12 +318,15 @@ label small {
 }
 
 /** Embed version **/
+
 .embed {
   color: #6a6a6a;
 }
+
 .embed #icon-list {
   margin: 0;
 }
+
 .embed h2 {
   font-size: 45px;
   font-style: italic;
@@ -263,6 +336,7 @@ label small {
 }
 
 /** Search input **/
+
 #search-input {
   width: 100%;
   padding: 15px 100px;
@@ -279,16 +353,19 @@ label small {
   background-repeat: no-repeat;
   color: #333;
 }
+
 #search-input.filled {
   background-color: #C9E1FB;
   border-color: #0a84ff;
 }
+
 #search-input[disabled] {
   opacity: 0.5;
   background-color: white;
 }
 
 /** Directory display **/
+
 .directory-display::before {
   content: attr(data-category);
   color: #737373;
@@ -298,6 +375,7 @@ label small {
   margin-bottom: 15px;
   text-transform: capitalize;
 }
+
 .directory-display {
   border-bottom: 1px solid #ebebeb;
   padding-bottom: 10px;
@@ -305,6 +383,7 @@ label small {
 }
 
 /** Icon display **/
+
 .icon-display {
   display: inline-block;
   padding: 10px 5px;
@@ -317,18 +396,22 @@ label small {
   text-decoration: none;
   margin-right: 2px;
 }
+
 .icon-display:hover,
 .icon-display.selected {
   background: #ebebeb;
 }
+
 .icon-display:active {
   background: #0a84ff;
   color: #f9f9fa;
 }
+
 .icon-display:active img {
   -webkit-filter: contrast(0) brightness(200%);
   filter: contrast(0) brightness(200%);
 }
+
 .icon-display img {
   transition: filter 0.1s;
   max-width: 16px;
@@ -337,6 +420,7 @@ label small {
   -moz-user-select: none;
   user-select: none;
 }
+
 .icon-display::after {
   content: attr(data-icon);
   font-size: 10px;

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -249,7 +249,8 @@ label small {
   display: inline-block;
   float: right;
   width: 40px;
-  height: 20px;
+  height: 22px;
+  margin-top: -1px;
 }
 
 /* Hide default HTML checkbox */
@@ -271,8 +272,8 @@ label small {
 .toggle:before {
   position: absolute;
   content: "";
-  height: 18px;
-  width: 18px;
+  height: 20px;
+  width: 20px;
   left: 0;
   bottom: 0;
   background-color: white;

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -77,7 +77,7 @@ body {
   width: 400px;
   padding: 24px 48px;
   border-top: solid 1px rgba(0, 0, 0, 0.1);
-  background-color: rgba(215, 215, 219, .2);
+  background-color: var(--grey-10);
 }
 
 #icon-details.show {

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -1,6 +1,7 @@
 @import url(https://fonts.googleapis.com/css?family=Fira+Sans:400,300);
 
 :root {
+  --white: #ffffff;
   --blue-50: #0a84ff;
   --blue-60: #0060df;
   --grey-10: #f9f9fa;
@@ -38,7 +39,7 @@ body {
   font-size: 40px;
   font-weight: 400;
   padding: 50px 100px;
-  background: white;
+  background-color: var(--white);
 }
 
 #icon-list {
@@ -48,7 +49,7 @@ body {
 /** icon details **/
 
 #icon-details {
-  background: white;
+  background-color: var(--white);
   height: 100vh;
   position: fixed;
   right: -440px;
@@ -175,7 +176,7 @@ body {
 
 #icon-details [type="checkbox"]:not(:checked) + label::before, 
 #icon-details [type="checkbox"]:checked + label::before {
-  background-color: white;
+  background-color: var(--white);
   border: 1px solid var(--grey-30);
   border-radius: 3px;
   content: '';
@@ -223,7 +224,7 @@ body {
 
 #icon-details [type="radio"]:not(:checked) + label::before, 
 #icon-details [type="radio"]:checked + label::before {
-  background: white;
+  background: var(--white);
   border: 1px solid var(--grey-30);
   border-radius: 100%;
   content: '';
@@ -283,7 +284,7 @@ label small {
   width: 20px;
   left: 0;
   bottom: 0;
-  background-color: white;
+  background-color: var(--white);
   transition: all .3s var(--photon-timing-fuction);
   border-radius: 100%;
   border: 1px solid var(--grey-30);
@@ -309,7 +310,7 @@ input:checked + .toggle:before {
 #download a {
   display: block;
   background-color: var(--blue-50);
-  color: white;
+  color: var(--white);
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   padding: 12px 24px;
@@ -320,7 +321,7 @@ input:checked + .toggle:before {
 /** Embed version **/
 
 .embed {
-  color: #6a6a6a;
+  color: var(--grey-50);
 }
 
 .embed #icon-list {
@@ -344,31 +345,30 @@ input:checked + .toggle:before {
   font-family: inherit;
   font-size: 20px;
   border-width: 0 0 1px 0;
-  border-color: #eee;
+  border-color: var(--grey-30);
   border-style: solid;
   position: sticky;
   top: 50px;
   background-image: url(../../icons/new/search-16.svg);
   background-position: calc((100px - 16px) / 2) center;
   background-repeat: no-repeat;
-  color: #333;
+  color: var(--grey-90);
 }
 
 #search-input.filled {
-  background-color: #C9E1FB;
-  border-color: #0a84ff;
+  border-color: var(--blue-50);
 }
 
 #search-input[disabled] {
   opacity: 0.5;
-  background-color: white;
+  background-color: var(--white);
 }
 
 /** Directory display **/
 
 .directory-display::before {
   content: attr(data-category);
-  color: #737373;
+  color: var(--grey-70);
   display: block;
   font-weight: 400;
   font-size: 16px;
@@ -377,7 +377,7 @@ input:checked + .toggle:before {
 }
 
 .directory-display {
-  border-bottom: 1px solid #ebebeb;
+  border-bottom: 1px solid var(--grey-30);
   padding-bottom: 10px;
   margin-bottom: 28px;
 }
@@ -399,12 +399,12 @@ input:checked + .toggle:before {
 
 .icon-display:hover,
 .icon-display.selected {
-  background: #ebebeb;
+  background: var(--grey-30);
 }
 
 .icon-display:active {
-  background: #0a84ff;
-  color: #f9f9fa;
+  background-color: var(--blue-50);
+  color: var(--white);
 }
 
 .icon-display:active img {

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -67,6 +67,7 @@ body {
 }
 
 #icon-details main {
+  flex-grow: 1;
   padding: 0 48px;
 }
 

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -50,10 +50,10 @@ body {
 
 #icon-details {
   background-color: var(--white);
-  height: 100vh;
+  height: calc(100vh - 50px);
   position: fixed;
   right: -440px;
-  top: 0;
+  top: 50px;
   transition: right 1s var(--photon-timing-fuction);
   width: 400px;
   border-left: solid 1px rgba(0, 0, 0, 0.1);

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -93,12 +93,15 @@ body {
 #icon-details .close-button {
   background-image: url('../../icons/new/stop-16.svg');
   background-position: center;
-  background-size: contain;
+  background-size: 16px 16px;
+  background-repeat: no-repeat;
+  transition: all 0.1s var(--photon-timing-fuction);
   position: absolute;
   top: 24px;
   right: 24px;
   width: 24px;
   height: 24px;
+  cursor: pointer;
 }
 
 #icon-details .close-button:hover {
@@ -106,7 +109,7 @@ body {
 }
 
 #icon-details .close-button:active {
-  background-color: var(--grey-50);
+  transform: scale(1.2);
 }
 
 #icon-details .section {
@@ -296,14 +299,6 @@ input:checked + .toggle:before {
 
 #download {
   text-align: right;
-  cursor: pointer;
-}
-
-#cancel a {
-  display: block;
-  color: var(--grey-90);
-  margin: 12px 24px;
-  text-decoration: none;
   cursor: pointer;
 }
 

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -68,7 +68,7 @@ body {
 }
 
 #icon-details footer {
-  position: fixed;
+  position: absolute;
   z-index: 1;
   bottom: 0;
   display: flex;

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -140,7 +140,7 @@ body {
 
 /** icon details checkbox **/
 
-.checkbox, 
+.checkbox,
 .radio {
   margin: 12px 0;
 }
@@ -175,7 +175,7 @@ body {
 
 #icon-details [type="checkbox"]:not(:checked) + label::before, 
 #icon-details [type="checkbox"]:checked + label::before {
-  background: white;
+  background-color: white;
   border: 1px solid var(--grey-30);
   border-radius: 3px;
   content: '';
@@ -196,7 +196,7 @@ body {
 #icon-details [type="radio"]:not(:checked) + label, 
 #icon-details [type="radio"]:checked + label {
   cursor: pointer;
-  padding: 0 32px;
+  padding-left: 32px;
   position: relative;
 }
 
@@ -214,8 +214,11 @@ body {
   content: '';
   width: 12px;
   height: 12px;
-  background-color: var(--blue-50);
   border-radius: 100%;
+}
+
+#icon-details [type="radio"]:checked + label::after {
+  background-color: var(--blue-50);
 }
 
 #icon-details [type="radio"]:not(:checked) + label::before, 
@@ -246,9 +249,7 @@ label small {
   text-transform: uppercase;
 }
 
-/** Toggle **/
-
- /* The switch - the box around the slider */
+/** Switch **/
 
 .switch {
   position: relative;
@@ -259,10 +260,10 @@ label small {
   margin-top: -1px;
 }
 
-/* Hide default HTML checkbox */
 .switch input {display:none;}
 
-/* The slider */
+/* Toggle */
+
 .toggle {
   position: absolute;
   cursor: pointer;

--- a/html/viewer/css/app.css
+++ b/html/viewer/css/app.css
@@ -86,7 +86,7 @@ body {
 }
 
 #icon-details h1 {
-  font-size: 32px;
+  font-size: 24px;
   font-weight: 400;
   margin: 0 0 24px 0;
 }
@@ -146,95 +146,6 @@ body {
   margin: 12px 0;
 }
 
-#icon-details [type="checkbox"]:not(:checked) + label, 
-#icon-details [type="checkbox"]:checked + label {
-  cursor: pointer;
-  padding-left: 32px;
-  position: relative;
-}
-
-#icon-details [type="checkbox"]:not(:checked), 
-#icon-details [type="checkbox"]:checked {
-  offset-inline-start: -9999px;
-  position: absolute;
-}
-
-#icon-details [type="checkbox"]:not(:checked) + label::after, 
-#icon-details [type="checkbox"]:checked + label::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  padding: 3px;
-  width: 16px;
-  height: 16px;
-  offset-inline-start: 0;
-}
-
-#icon-details [type="checkbox"]:checked + label::after {
-  background: url("../images/check.svg") no-repeat center center;
-}
-
-#icon-details [type="checkbox"]:not(:checked) + label::before, 
-#icon-details [type="checkbox"]:checked + label::before {
-  background-color: var(--white);
-  border: 1px solid var(--grey-30);
-  border-radius: 3px;
-  content: '';
-  height: 20px;
-  offset-inline-start: 0;
-  position: absolute;
-  top: 0;
-  width: 20px;
-}
-
-#icon-details [type="checkbox"]:disabled + label{
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/** icons details radio **/
-
-#icon-details [type="radio"]:not(:checked) + label, 
-#icon-details [type="radio"]:checked + label {
-  cursor: pointer;
-  padding-left: 32px;
-  position: relative;
-}
-
-#icon-details [type="radio"]:not(:checked), 
-#icon-details [type="radio"]:checked {
-  offset-inline-start: -9999px;
-  position: absolute;
-}
-
-#icon-details [type="radio"]:not(:checked) + label::after, 
-#icon-details [type="radio"]:checked + label::after {
-  position: absolute;
-  top: 5px;
-  left: 5px;
-  content: '';
-  width: 12px;
-  height: 12px;
-  border-radius: 100%;
-}
-
-#icon-details [type="radio"]:checked + label::after {
-  background-color: var(--blue-50);
-}
-
-#icon-details [type="radio"]:not(:checked) + label::before, 
-#icon-details [type="radio"]:checked + label::before {
-  background: var(--white);
-  border: 1px solid var(--grey-30);
-  border-radius: 100%;
-  content: '';
-  width: 20px;
-  height: 20px;
-  offset-inline-start: 0;
-  position: absolute;
-  top: 0;
-}
-
 label span {
   display: inline;
   vertical-align: bottom;
@@ -248,46 +159,6 @@ label small {
   margin-left: 12px;
   font-weight: 400;
   text-transform: uppercase;
-}
-
-/** Switch **/
-
-.switch {
-  position: relative;
-  display: inline-block;
-  float: right;
-  width: 40px;
-  height: 22px;
-  margin-top: -1px;
-}
-
-.switch input {display:none;}
-
-/* Toggle */
-
-.toggle {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--grey-30);
-  transition: all .3s var(--photon-timing-fuction);
-  border-radius: 20px;
-}
-
-.toggle:before {
-  position: absolute;
-  content: "";
-  height: 20px;
-  width: 20px;
-  left: 0;
-  bottom: 0;
-  background-color: var(--white);
-  transition: all .3s var(--photon-timing-fuction);
-  border-radius: 100%;
-  border: 1px solid var(--grey-30);
 }
 
 input:checked + .toggle,

--- a/html/viewer/css/input-checkbox.css
+++ b/html/viewer/css/input-checkbox.css
@@ -1,0 +1,45 @@
+#icon-details [type="checkbox"]:not(:checked) + label, 
+#icon-details [type="checkbox"]:checked + label {
+  cursor: pointer;
+  padding-left: 32px;
+  position: relative;
+}
+
+#icon-details [type="checkbox"]:not(:checked), 
+#icon-details [type="checkbox"]:checked {
+  left: -9999px;
+  position: absolute;
+}
+
+#icon-details [type="checkbox"]:not(:checked) + label::after, 
+#icon-details [type="checkbox"]:checked + label::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  padding: 3px;
+  width: 16px;
+  height: 16px;
+  left: 0;
+}
+
+#icon-details [type="checkbox"]:checked + label::after {
+  background: url("../images/check.svg") no-repeat center center;
+}
+
+#icon-details [type="checkbox"]:not(:checked) + label::before, 
+#icon-details [type="checkbox"]:checked + label::before {
+  background-color: var(--white);
+  border: 1px solid var(--grey-30);
+  border-radius: 3px;
+  content: '';
+  height: 20px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 20px;
+}
+
+#icon-details [type="checkbox"]:disabled + label{
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/html/viewer/css/input-radio.css
+++ b/html/viewer/css/input-radio.css
@@ -1,0 +1,40 @@
+#icon-details [type="radio"]:not(:checked) + label, 
+#icon-details [type="radio"]:checked + label {
+  cursor: pointer;
+  padding-left: 32px;
+  position: relative;
+}
+
+#icon-details [type="radio"]:not(:checked), 
+#icon-details [type="radio"]:checked {
+  left: -9999px;
+  position: absolute;
+}
+
+#icon-details [type="radio"]:not(:checked) + label::after, 
+#icon-details [type="radio"]:checked + label::after {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  content: '';
+  width: 12px;
+  height: 12px;
+  border-radius: 100%;
+}
+
+#icon-details [type="radio"]:checked + label::after {
+  background-color: var(--blue-50);
+}
+
+#icon-details [type="radio"]:not(:checked) + label::before, 
+#icon-details [type="radio"]:checked + label::before {
+  background: var(--white);
+  border: 1px solid var(--grey-30);
+  border-radius: 100%;
+  content: '';
+  width: 20px;
+  height: 20px;
+  left: 0;
+  position: absolute;
+  top: 0;
+}

--- a/html/viewer/css/input-toggle-switch.css
+++ b/html/viewer/css/input-toggle-switch.css
@@ -1,0 +1,35 @@
+.switch {
+  position: relative;
+  display: inline-block;
+  float: right;
+  width: 40px;
+  height: 22px;
+  margin-top: -1px;
+}
+
+.switch input {display:none;}
+
+.toggle {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--grey-30);
+  transition: all .3s var(--photon-timing-fuction);
+  border-radius: 20px;
+}
+
+.toggle:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 0;
+  bottom: 0;
+  background-color: var(--white);
+  transition: all .3s var(--photon-timing-fuction);
+  border-radius: 100%;
+  border: 1px solid var(--grey-30);
+}

--- a/html/viewer/images/check.svg
+++ b/html/viewer/images/check.svg
@@ -2,5 +2,5 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="#FFF" d="M7.293 12.707a1 1 0 0 0 1.414 0l5-5a1 1 0 0 0-1.414-1.414L9 9.586V1a1 1 0 1 0-2 0v8.586L3.707 6.293a1 1 0 0 0-1.414 1.414zM13 14H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"/>
+  <path fill="#0a84ff" d="M6 14a1 1 0 0 1-.707-.293l-3-3a1 1 0 0 1 1.414-1.414l2.157 2.157 6.316-9.023a1 1 0 0 1 1.639 1.146l-7 10a1 1 0 0 1-.732.427A.863.863 0 0 1 6 14z"/>
 </svg>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -20,7 +20,7 @@
         <div class="section">
           <div class="title">Platform</div>
           <div class="checkbox">
-            <input type="checkbox" id="desktop-web"><label for="desktop-web"><span>Desktop and web</span></label><br>
+            <input type="checkbox" id="desktop-web" checked><label for="desktop-web"><span>Desktop/Web</span></label><br>
           </div class="checkbox">
           <div class="checkbox">
             <input type="checkbox" id="ios" disabled><label for="ios"><span>iOS</span><small>Coming Soon</small></label><br>
@@ -42,7 +42,7 @@
           </div>
         </div>
         <div class="section">
-          <div class="title">Include Source</div>
+          <div class="title">Include Source File</div>
           <label class="switch">
             <input type="checkbox">
             <div class="toggle"></div>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -27,7 +27,7 @@
           </div class="checkbox">
           <div class="checkbox">
             <input type="checkbox" id="Android" disabled><label for="android"><span>Android</span><small>Coming Soon</small></label>
-          </div class="checkbox">
+          </div>
         </div>
         <div class="section">
           <div class="title">Fill</div>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -41,7 +41,8 @@
             <input type="radio" name="fill" id="light"><label for="light"><span>Light</span></label><br>
           </div>
         </div>
-        <div class="section">
+        <!-- Display this section only if iOS and/or Android checkboxes are selected -->
+        <div class="section" style="display: none">
           <div class="title">Include Source File</div>
           <label class="switch">
             <input type="checkbox">

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -71,5 +71,6 @@
   <script src="js/icon-styles.js"></script>
   <script src="js/icon-list.js"></script>
   <script src="js/app.js"></script>
+  <script src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
 </body>
 </html>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -32,13 +32,13 @@
         <div class="section">
           <div class="title">Fill</div>
           <div class="radio">
-            <input type="radio" id="context-fill"><label for="context-fill"><span>Context Fill</span></label>
+            <input type="radio" name="fill" id="context-fill" checked><label for="context-fill"><span>Context Fill</span></label>
           </div>
           <div class="radio">
-            <input type="radio" id="dark"><label for="dark"><span>Dark</span></label><br>
+            <input type="radio" name="fill" id="dark"><label for="dark"><span>Dark</span></label><br>
           </div>
           <div class="radio">
-            <input type="radio" id="light"><label for="light"><span>Light</span></label><br>
+            <input type="radio" name="fill" id="light"><label for="light"><span>Light</span></label><br>
           </div>
         </div>
         <div class="section">

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -5,35 +5,52 @@
   <link href="css/app.css" rel="stylesheet"/>
 </head>
 <body>
-  <div id="headline">Firefox Icons</div>
+  <div id="headline">Photon Icons</div>
   <input type="text" placeholder="Search Icons" id="search-input"/>
   <div id="icon-list" hidden></div>
   <div id="loading">Loading icons...</div>
-  <div id="icon-details">
-    <h1>Download your icon.<div class="close-button"></div></h1>
-    <div class="preview"></div>
-    <div class="name"></div>
-    <div class="options">
-      <div class="section">
-        <div class="title">Select your size:</div>
-        <input type="checkbox" id="size-16"><label for="size-16">16x16</label><br>
-        <input type="checkbox" id="size-24"><label for="size-24">24x24</label><br>
-        <input type="checkbox" id="size-32"><label for="size-32">32x32</label><br>
-        <input type="checkbox" id="size-64"><label for="size-64">64x64</label><br>
-        <input type="checkbox" id="size-other"><label for="size-other">Other</label><br>
+  <div id="icon-details" class="show">
+    <header>
+      <h1>Download<div class="close-button"></div></h1>
+    </header>
+    <main>
+      <div class="preview"></div>
+      <div class="name"></div>
+      <div class="options">
+        <div class="section">
+          <div class="title">Platform</div>
+          <div class="checkbox">
+            <input type="checkbox" id="desktop-web"><label for="desktop-web"><span>Desktop and web</span></label><br>
+          </div class="checkbox">
+          <div class="checkbox">
+            <input type="checkbox" id="ios" disabled><label for="ios"><span>iOS</span><small>Coming Soon</small></label><br>
+          </div class="checkbox">
+          <div class="checkbox">
+            <input type="checkbox" id="Android" disabled><label for="android"><span>Android</span><small>Coming Soon</small></label>
+          </div class="checkbox">
+        </div>
+        <div class="section">
+          <div class="title">Fill</div>
+          <div class="radio">
+            <input type="radio" id="context-fill"><label for="context-fill"><span>Context Fill</span></label>
+          </div>
+          <div class="radio">
+            <input type="radio" id="dark"><label for="dark"><span>Dark</span></label><br>
+          </div>
+          <div class="radio">
+            <input type="radio" id="light"><label for="light"><span>Light</span></label><br>
+          </div>
+        </div>
       </div>
-      <div class="section">
-        <div class="title">Select your color:</div>
-        <select id="color">
-          <option value="context-fill" selected>Context-fill</option>
-          <option value="black">Black</option>
-          <option value="white">White</option>
-        </select>
+    </main>
+    <footer>
+      <div id="cancel">
+        <a>Cancel</a>
       </div>
-    </div>
-    <div id="download">
-      <a><img src="download-white.svg"> Download</a>
-    </div>
+      <div id="download">
+        <a>Download</a>
+      </div>
+    </footer>
   </div>
 
   <script>
@@ -49,6 +66,5 @@
   <script src="js/icon-styles.js"></script>
   <script src="js/icon-list.js"></script>
   <script src="js/app.js"></script>
-  <script src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
 </body>
 </html>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -41,6 +41,13 @@
             <input type="radio" id="light"><label for="light"><span>Light</span></label><br>
           </div>
         </div>
+        <div class="section">
+          <div class="title">Include Source File</div>
+          <label class="switch">
+            <input type="checkbox">
+            <div class="toggle"></div>
+          </label>
+        </div>
       </div>
     </main>
     <footer>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -3,6 +3,9 @@
 <head>
   <title>Firefox Icons</title>
   <link href="css/app.css" rel="stylesheet"/>
+  <link href="css/input-checkbox.css" rel="stylesheet"/>
+  <link href="css/input-radio.css" rel="stylesheet"/>
+  <link href="css/input-toggle-switch.css" rel="stylesheet"/>
 </head>
 <body>
   <div id="headline">Photon Icons</div>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -9,7 +9,7 @@
   <input type="text" placeholder="Search Icons" id="search-input"/>
   <div id="icon-list" hidden></div>
   <div id="loading">Loading icons...</div>
-  <div id="icon-details" class="show">
+  <div id="icon-details">
     <header>
       <h1>Download<div class="close-button"></div></h1>
     </header>
@@ -42,7 +42,7 @@
           </div>
         </div>
         <div class="section">
-          <div class="title">Include Source File</div>
+          <div class="title">Include Source</div>
           <label class="switch">
             <input type="checkbox">
             <div class="toggle"></div>
@@ -51,9 +51,6 @@
       </div>
     </main>
     <footer>
-      <div id="cancel">
-        <a>Cancel</a>
-      </div>
       <div id="download">
         <a>Download</a>
       </div>

--- a/html/viewer/index.html
+++ b/html/viewer/index.html
@@ -21,7 +21,7 @@
           <div class="title">Platform</div>
           <div class="checkbox">
             <input type="checkbox" id="desktop-web" checked><label for="desktop-web"><span>Desktop/Web</span></label><br>
-          </div class="checkbox">
+          </div>
           <div class="checkbox">
             <input type="checkbox" id="ios" disabled><label for="ios"><span>iOS</span><small>Coming Soon</small></label><br>
           </div class="checkbox">


### PR DESCRIPTION
I styled the sidebar following the design of the preferences sidebar of activity stream. I manually copied some of the styles (having a checkbox or radio button component would have been really helpful 😅). The CSS needs some cleaning/refactoring but I think we can do it before merging to production.

The naming of the options is temporary. In the meantime I placed 'Light' that corresponds to Grey 10 with 80% alpha channel and 'Dark' that corresponds to Grey 90 at 80%.

(I couldn't manage to run the website locally, if I run `npm run serve` I get a 404 page)